### PR TITLE
feat: lexical blocks support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - `data-preview-ignore` attribute — add to any element (in preview or in admin custom block components) to prevent clicks on it from triggering scroll sync in either direction
 - New message types: `scroll-to-richtext-block`, `focus-richtext-block`, `scroll-to-richtext-nested-block`; optional `richTextBlockId` field on `FocusBlockMessage`
 ### Fixed
-- **BREAKING**: Updated iframe selector from `iframe.live-preview-iframe` (class) to `iframe#live-preview-iframe` (ID) — required for compatibility with latest Payload versions which changed the live preview iframe rendering and no longer sets the class on the element
+- **BREAKING**: Updated iframe selector from `iframe.live-preview-iframe` (class) to `iframe#live-preview-iframe` (ID) — required for compatibility with v3.81.0+ Payload version which changed the live preview iframe rendering and no longer sets the class on the element
 
 ## [2.0.0] 2026-03-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+- RichText (Lexical) block sync — full bi-directional sync for blocks embedded inside Lexical richText fields
+- `BetterPreviewLexicalFeature` — server feature that stamps `data-block-id` onto every block decorator element in the Lexical editor DOM; exported from `payload-better-preview`
+- `BetterPreviewClientFeature` — client feature exported from `payload-better-preview/lexical`
+- `data-preview-ignore` attribute — add to any element (in preview or in admin custom block components) to prevent clicks on it from triggering scroll sync in either direction
+- New message types: `scroll-to-richtext-block`, `focus-richtext-block`, `scroll-to-richtext-nested-block`; optional `richTextBlockId` field on `FocusBlockMessage`
+### Fixed
+- **BREAKING**: Updated iframe selector from `iframe.live-preview-iframe` (class) to `iframe#live-preview-iframe` (ID) — required for compatibility with latest Payload versions which changed the live preview iframe rendering and no longer sets the class on the element
+
 ## [2.0.0] 2026-03-23
 ### Added
 - Nested block support — bi-directional sync works at any block nesting depth, ancestor rows are automatically expanded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org).
 - `data-preview-ignore` attribute — add to any element (in preview or in admin custom block components) to prevent clicks on it from triggering scroll sync in either direction
 - New message types: `scroll-to-richtext-block`, `focus-richtext-block`, `scroll-to-richtext-nested-block`; optional `richTextBlockId` field on `FocusBlockMessage`
 ### Fixed
-- **BREAKING**: Updated iframe selector from `iframe.live-preview-iframe` (class) to `iframe#live-preview-iframe` (ID) — required for compatibility with v3.81.0+ Payload version which changed the live preview iframe rendering and no longer sets the class on the element
+- Fixed live preview iframe detection for Payload 3.81+ which no longer sets the `live-preview-iframe` class on the iframe element; selector now checks ID first (`iframe#live-preview-iframe`) with fallbacks for older versions
 
 ## [2.0.0] 2026-03-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,6 +142,129 @@ export function NestedBlockRenderer({ block, index, field }) {
 }
 ```
 
+## RichText (Lexical) blocks
+
+Payload's Lexical editor supports blocks embedded directly inside richText fields. The plugin provides full bi-directional sync for these blocks too.
+
+### 1. Register the Lexical feature
+
+Add `BetterPreviewLexicalFeature` to your Lexical editor config. This injects a client-side plugin that stamps each block in the editor with a `data-block-id` attribute so the admin can locate them:
+
+```ts
+// payload.config.ts
+import { betterPreview, BetterPreviewLexicalFeature } from 'payload-better-preview'
+import { lexicalEditor, BlocksFeature } from '@payloadcms/richtext-lexical'
+
+export default buildConfig({
+  plugins: [betterPreview()],
+  editor: lexicalEditor({
+    features: ({ defaultFeatures }) => [
+      ...defaultFeatures,
+      BlocksFeature({ blocks: [...] }),
+      BetterPreviewLexicalFeature(),
+    ],
+  }),
+})
+```
+
+### 2. Add data attributes in JSX converters
+
+Add `data-block-id` (the block's unique ID from `node.fields.id`) to each block wrapper. The plugin uses this ID to sync between admin and preview:
+
+```tsx
+// jsxConverters.tsx
+import { JSXConvertersFunction } from '@payloadcms/richtext-lexical/react'
+
+export const jsxConverters: JSXConvertersFunction = ({ defaultConverters }) => ({
+  ...defaultConverters,
+  blocks: {
+    hero: ({ node }) => (
+      <div
+        data-block={node.fields.blockType}
+        data-block-id={node.fields.id}         // required for richText sync
+      >
+        {/* block content */}
+      </div>
+    ),
+  },
+})
+```
+
+### How it works
+
+- **`data-block-id`** identifies each block uniquely across both admin and preview
+- **Admin → Preview**: clicking a Lexical block in the admin sends `scroll-to-richtext-block` with the block ID — the preview finds `[data-block-id]` and scrolls to it
+- **Preview → Admin**: clicking a block with `data-block-id` (but no `data-block-field`) sends `focus-richtext-block` — the admin finds `[data-block-id]`, expands the collapsible if needed, and scrolls to it
+
+### Disabling sync on specific elements
+
+Add `data-preview-ignore` to any element to prevent clicks on it from triggering scroll sync. Works in both directions — in the preview (blocks rendered on the frontend) and in the admin (custom block components inside the Lexical editor).
+
+Useful for interactive elements like buttons, links, or custom controls inside a block component:
+
+```tsx
+// jsxConverters.tsx — preview side
+blocks: {
+  cta: ({ node }) => (
+    <div
+      data-block={node.fields.blockType}
+      data-block-id={node.fields.id}
+    >
+      <h2>{node.fields.title}</h2>
+      {/* clicks here will NOT trigger scroll sync */}
+      <button data-preview-ignore onClick={...}>
+        Buy now
+      </button>
+    </div>
+  ),
+},
+```
+
+```tsx
+// Custom block component — admin side (Lexical editor)
+export function CtaBlockComponent({ formData }) {
+  return (
+    <div>
+      <p>{formData.title}</p>
+      {/* clicks here will NOT send scroll-to-preview message */}
+      <button data-preview-ignore onClick={openModal}>
+        Edit link
+      </button>
+    </div>
+  )
+}
+```
+
+Any click originating inside a `[data-preview-ignore]` element is ignored by the plugin entirely — hover highlighting and scroll sync are both skipped for that interaction.
+
+### Nested blocks inside richText
+
+For blocks that are nested inside a richText block (e.g. a `nestedBlock` with its own `blocks` field), sync works the same as regular nested blocks. The plugin automatically detects the parent richText block and scopes the search to avoid duplicate IDs.
+
+Add `data-block-field` and `data-block-index` to nested blocks (but NOT to direct richText blocks since they have no field path):
+
+```tsx
+// For the outer richText block (nestedBlock):
+<div
+  data-block={node.fields.blockType}
+  data-block-id={node.fields.id}
+>
+  <RenderBlocks
+    blocks={node.fields.content}
+    field="content"               // local field name only (not full path)
+    richTextBlockId={node.fields.id}
+  />
+</div>
+
+// For inner blocks (BlockRenderer receives richTextBlockId from parent):
+<div
+  data-block={block.blockType}
+  data-block-id={block.id}
+  data-block-index={index}
+  data-block-field={field}        // e.g. "content"
+>
+```
+
 ## Plugin options
 
 | Option | Type | Default | Description |
@@ -187,9 +310,16 @@ function MyToggle({ enabled, onToggle }: ToggleProps) {
 
 ## How it works
 
-- **Admin → Preview**: clicking anywhere inside a block row in the admin sends a `scroll-to-block` message to the preview iframe. The preview scrolls to the matching `[data-block-field][data-block-index]` element and shows a highlight overlay.
-- **Preview → Admin**: clicking a block in the preview sends a `focus-block` message to the admin. The admin expands all ancestor rows (for nested blocks), then scrolls to and highlights the target block row.
-- All communication is via `window.postMessage`. No network requests, no shared state.
+**Block fields (standard):**
+- **Admin → Preview**: clicking a block row in the admin sends `scroll-to-block` with `{ field, index }` to the preview iframe. The preview finds `[data-block-field][data-block-index]` and scrolls to it.
+- **Preview → Admin**: clicking a block with `data-block-field` sends `focus-block`. The admin expands all ancestor rows and scrolls to the target row.
+
+**RichText (Lexical) blocks:**
+- **Admin → Preview**: clicking a Lexical block sends `scroll-to-richtext-block` with `{ blockId }`. The preview finds `[data-block-id]` and scrolls to it.
+- **Preview → Admin**: clicking a block with `data-block-id` (but no `data-block-field`) sends `focus-richtext-block`. The admin finds `[data-block-id]`, expands the collapsible if needed, and scrolls to it.
+- **Nested blocks inside richText**: clicking sends `focus-block` with an extra `richTextBlockId`. The admin opens the parent Lexical block, then scopes the row search within it — avoiding duplicate ID issues when multiple identical blocks exist.
+
+All communication is via `window.postMessage`. No network requests, no shared state.
 
 `<BetterPreview />` is a `'use client'` component that renders `null` (no React DOM output). It injects 3 absolutely-positioned DOM elements into `document.body`:
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/client.js",
       "types": "./dist/client.d.ts",
       "default": "./dist/client.js"
+    },
+    "./lexical": {
+      "import": "./dist/lexicalFeature/feature.client.js",
+      "types": "./dist/lexicalFeature/feature.client.d.ts",
+      "default": "./dist/lexicalFeature/feature.client.js"
     }
   },
   "main": "./dist/index.js",
@@ -54,13 +59,13 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
-    "@payloadcms/db-mongodb": "3.68.5",
-    "@payloadcms/db-postgres": "3.68.5",
-    "@payloadcms/db-sqlite": "3.68.5",
+    "@payloadcms/db-mongodb": "3.81.0",
+    "@payloadcms/db-postgres": "3.81.0",
+    "@payloadcms/db-sqlite": "3.81.0",
     "@payloadcms/eslint-config": "3.9.0",
-    "@payloadcms/next": "3.68.5",
-    "@payloadcms/richtext-lexical": "3.68.5",
-    "@payloadcms/ui": "3.68.5",
+    "@payloadcms/next": "3.81.0",
+    "@payloadcms/richtext-lexical": "3.81.0",
+    "@payloadcms/ui": "3.81.0",
     "@playwright/test": "1.58.2",
     "@swc-node/register": "1.10.9",
     "@swc/cli": "0.6.0",
@@ -75,7 +80,7 @@
     "mongodb-memory-server": "10.1.4",
     "next": "15.4.11",
     "open": "^10.1.0",
-    "payload": "3.68.5",
+    "payload": "3.81.0",
     "prettier": "^3.4.2",
     "qs-esm": "7.0.2",
     "react": "19.2.1",

--- a/src/AdminBlockSyncProvider.tsx
+++ b/src/AdminBlockSyncProvider.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import React, { useEffect } from 'react'
-import { DEFAULT_ACCENT_COLOR, FLASH_DURATION, makeColors } from './constants'
-import type { ScrollToBlockMessage } from './messages'
-import { MESSAGE_PREFIX, isFocusBlockMessage } from './messages'
+import { DEFAULT_ACCENT_COLOR, ATTR_IGNORE, FLASH_DURATION, makeColors } from './constants'
+import type { ScrollToBlockMessage, ScrollToRichTextBlockMessage, ScrollToRichTextNestedBlockMessage } from './messages'
+import { MESSAGE_PREFIX, isFocusBlockMessage, isFocusRichTextBlockMessage } from './messages'
 
 function getPreviewIframe(): HTMLIFrameElement | null {
   return document.querySelector<HTMLIFrameElement>(
-    'iframe.live-preview-iframe, iframe[src*="/preview"], iframe[title*="preview"]',
+    'iframe#live-preview-iframe, iframe.live-preview-iframe, iframe[src*="/preview"], iframe[title*="preview"]',
   )
 }
 
@@ -21,6 +21,11 @@ function extractBlockLocation(el: Element): { field: string; index: number } | n
 
 function findBlockRow(field: string, index: number): Element | null {
   return document.querySelector(`[id="${field}-row-${index}"]`)
+}
+
+function extractRichTextBlockId(el: Element): string | null {
+  const block = el.closest('[data-block-id]')
+  return block?.getAttribute('data-block-id') ?? null
 }
 
 function expandIfCollapsed(row: Element): void {
@@ -96,29 +101,97 @@ export const AdminBlockSyncProvider: React.FC<Props> = ({ children, accentColor,
       if (!target) return
 
       if ((target as Element).closest('.collapsible__toggle')) return
-
-      const location = extractBlockLocation(target)
-      if (!location) return
+      if ((target as Element).closest(`[${ATTR_IGNORE}]`)) return
 
       const iframe = getPreviewIframe()
       if (!iframe?.contentWindow) return
 
-      const message: ScrollToBlockMessage = {
-        type: `${MESSAGE_PREFIX}scroll-to-block`,
-        field: location.field,
-        index: location.index,
+      const location = extractBlockLocation(target)
+      if (location) {
+        // If the row is inside a Lexical richText block, scope by parent block ID
+        const lexicalParent = target.closest('[data-block-id]')
+        if (lexicalParent) {
+          const richTextBlockId = lexicalParent.getAttribute('data-block-id')
+          if (richTextBlockId) {
+            const message: ScrollToRichTextNestedBlockMessage = {
+              type: `${MESSAGE_PREFIX}scroll-to-richtext-nested-block`,
+              richTextBlockId,
+              index: location.index,
+            }
+            iframe.contentWindow.postMessage(message, '*')
+            return
+          }
+        }
+
+        const message: ScrollToBlockMessage = {
+          type: `${MESSAGE_PREFIX}scroll-to-block`,
+          field: location.field,
+          index: location.index,
+        }
+        iframe.contentWindow.postMessage(message, '*')
+        return
       }
 
-      iframe.contentWindow.postMessage(message, '*')
+      const blockId = extractRichTextBlockId(target)
+      if (blockId) {
+        const message: ScrollToRichTextBlockMessage = {
+          type: `${MESSAGE_PREFIX}scroll-to-richtext-block`,
+          blockId,
+        }
+        iframe.contentWindow.postMessage(message, '*')
+      }
     }
 
     function handleMessage(e: MessageEvent) {
+      if (isFocusRichTextBlockMessage(e.data)) {
+        const iframe = getPreviewIframe()
+        if (!iframe?.contentWindow || e.source !== iframe.contentWindow) return
+
+        const el = document.querySelector(`[data-block-id="${e.data.blockId}"]`)
+        if (!el) return
+
+        const wasCollapsed = !!el.querySelector('.collapsible--collapsed')
+        expandIfCollapsed(el)
+
+        setTimeout(() => {
+          scrollToElement(el, scrollAlign, scrollOffset)
+          flashHighlightRow(el, colors)
+        }, wasCollapsed ? 350 : 0)
+        return
+      }
+
       if (!isFocusBlockMessage(e.data)) return
 
       const iframe = getPreviewIframe()
       if (!iframe?.contentWindow || e.source !== iframe.contentWindow) return
 
-      const { field, index } = e.data
+      const { field, index, richTextBlockId } = e.data
+
+      // Nested block inside a richText Lexical block
+      if (richTextBlockId) {
+        const parent = document.querySelector(`[data-block-id="${richTextBlockId}"]`)
+        if (!parent) return
+
+        const wasParentCollapsed = !!parent.querySelector('.collapsible--collapsed')
+        expandIfCollapsed(parent)
+
+        setTimeout(() => {
+          // Use local field name (last segment) to scope within the parent form
+          const localField = field.split('-').pop() ?? field
+          const row = parent.querySelector(`[id="${localField}-row-${index}"]`)
+          if (!row) return
+
+          const wasRowCollapsed = !!row.querySelector('.collapsible--collapsed')
+          expandIfCollapsed(row)
+
+          setTimeout(() => {
+            scrollToElement(row, scrollAlign, scrollOffset)
+            flashHighlightRow(row, colors)
+          }, wasRowCollapsed ? 350 : 0)
+        }, wasParentCollapsed ? 350 : 0)
+        return
+      }
+
       const ancestorIds = getAncestorRowIds(field)
 
       ancestorIds.forEach((id) => {

--- a/src/BetterPreview.tsx
+++ b/src/BetterPreview.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { ATTR, ATTR_INDEX, ATTR_FIELD, DEFAULT_ACCENT_COLOR, makeColors } from './constants'
-import { isScrollToBlockMessage, MESSAGE_PREFIX } from './messages'
-import type { FocusBlockMessage } from './messages'
+import { ATTR, ATTR_INDEX, ATTR_FIELD, ATTR_BLOCK_ID, ATTR_IGNORE, DEFAULT_ACCENT_COLOR, makeColors } from './constants'
+import { isScrollToBlockMessage, isScrollToRichTextBlockMessage, isScrollToRichTextNestedBlockMessage, MESSAGE_PREFIX } from './messages'
+import type { FocusBlockMessage, FocusRichTextBlockMessage } from './messages'
 import {
   createOverlay,
   createLabel,
@@ -115,14 +115,7 @@ export const BetterPreview: React.FC<Props> = ({ accentColor, showToggle = true,
       rafRef.current = requestAnimationFrame(updatePosition)
     }
 
-    function handleMessage(e: MessageEvent) {
-      if (!isScrollToBlockMessage(e.data)) return
-
-      const block = document.querySelector(
-        `[${ATTR_FIELD}="${e.data.field}"][${ATTR_INDEX}="${e.data.index}"]`,
-      )
-      if (!block) return
-
+    function scrollAndHighlight(block: Element) {
       currentBlockRef.current = block
       const rect = block.getBoundingClientRect()
       const parent = block.parentElement?.closest(`[${ATTR}]`)
@@ -149,28 +142,72 @@ export const BetterPreview: React.FC<Props> = ({ accentColor, showToggle = true,
       setTimeout(() => flashHighlight(block, colors), 400)
     }
 
+    function handleMessage(e: MessageEvent) {
+      if (isScrollToRichTextNestedBlockMessage(e.data)) {
+        const parent = document.querySelector(`[${ATTR_BLOCK_ID}="${e.data.richTextBlockId}"]`)
+        if (!parent) return
+        const block = parent.querySelector(`[${ATTR_INDEX}="${e.data.index}"]`)
+        if (block) scrollAndHighlight(block)
+        return
+      }
+
+      if (isScrollToRichTextBlockMessage(e.data)) {
+        const block = document.querySelector(`[${ATTR_BLOCK_ID}="${e.data.blockId}"]`)
+        if (block) scrollAndHighlight(block)
+        return
+      }
+
+      if (!isScrollToBlockMessage(e.data)) return
+
+      const block = document.querySelector(
+        `[${ATTR_FIELD}="${e.data.field}"][${ATTR_INDEX}="${e.data.index}"]`,
+      )
+      if (!block) return
+
+      scrollAndHighlight(block)
+    }
+
     function handleClick(e: MouseEvent) {
       const target = e.target as Element | null
       if (!target) return
 
+      if (target.closest(`[${ATTR_IGNORE}]`)) return
+
       const block = target.closest(`[${ATTR}]`)
       if (!block) return
 
-      const indexStr = block.getAttribute(ATTR_INDEX)
-      if (indexStr == null) return
-
-      const index = Number(indexStr)
-      if (Number.isNaN(index)) return
-
       const field = block.getAttribute(ATTR_FIELD)
-      if (!field) return
+      const indexStr = block.getAttribute(ATTR_INDEX)
 
-      const message: FocusBlockMessage = {
-        type: `${MESSAGE_PREFIX}focus-block`,
-        field,
-        index,
+      if (field && indexStr != null) {
+        const index = Number(indexStr)
+        if (Number.isNaN(index)) return
+
+        // If nested inside a richText block (parent has data-block-id but no data-block-field)
+        const parentWithId = block.parentElement?.closest(`[${ATTR_BLOCK_ID}]`)
+        const richTextBlockId =
+          parentWithId && !parentWithId.hasAttribute(ATTR_FIELD)
+            ? (parentWithId.getAttribute(ATTR_BLOCK_ID) ?? undefined)
+            : undefined
+
+        const message: FocusBlockMessage = {
+          type: `${MESSAGE_PREFIX}focus-block`,
+          field,
+          index,
+          ...(richTextBlockId !== undefined && { richTextBlockId }),
+        }
+        window.parent.postMessage(message, '*')
+        return
       }
-      window.parent.postMessage(message, '*')
+
+      const blockId = block.getAttribute(ATTR_BLOCK_ID)
+      if (blockId) {
+        const message: FocusRichTextBlockMessage = {
+          type: `${MESSAGE_PREFIX}focus-richtext-block`,
+          blockId,
+        }
+        window.parent.postMessage(message, '*')
+      }
     }
 
     document.addEventListener('mouseover', handleMouseOver)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,8 @@ export const ATTR = 'data-block'
 export const ATTR_INDEX = 'data-block-index'
 export const ATTR_NAME = 'data-block-name'
 export const ATTR_FIELD = 'data-block-field'
+export const ATTR_BLOCK_ID = 'data-block-id'
+export const ATTR_IGNORE = 'data-preview-ignore'
 
 export const DEFAULT_ACCENT_COLOR = '#3b82f6'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import type { Config } from 'payload'
 import type { BetterPreviewConfig } from './types'
 
 export type { BetterPreviewConfig }
+export { BetterPreviewLexicalFeature } from './lexicalFeature/feature.server'
 
 export const betterPreview =
   (pluginOptions?: BetterPreviewConfig) =>

--- a/src/lexicalFeature/feature.client.ts
+++ b/src/lexicalFeature/feature.client.ts
@@ -1,0 +1,8 @@
+'use client'
+
+import { createClientFeature } from '@payloadcms/richtext-lexical/client'
+import { BetterPreviewLexicalPlugin } from './plugin.js'
+
+export const BetterPreviewClientFeature = createClientFeature({
+  plugins: [{ Component: BetterPreviewLexicalPlugin, position: 'bottom' }],
+})

--- a/src/lexicalFeature/feature.server.ts
+++ b/src/lexicalFeature/feature.server.ts
@@ -1,0 +1,8 @@
+import { createServerFeature } from '@payloadcms/richtext-lexical'
+
+export const BetterPreviewLexicalFeature = createServerFeature({
+  feature: {
+    ClientFeature: 'payload-better-preview/lexical#BetterPreviewClientFeature',
+  },
+  key: 'betterPreviewLexical',
+})

--- a/src/lexicalFeature/plugin.tsx
+++ b/src/lexicalFeature/plugin.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import type { PluginComponent } from '@payloadcms/richtext-lexical'
+import { useLexicalComposerContext } from '@payloadcms/richtext-lexical/lexical/react/LexicalComposerContext'
+import { useEffect } from 'react'
+
+export const BetterPreviewLexicalPlugin: PluginComponent = () => {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    return editor.registerUpdateListener(({ editorState }) => {
+      const blockNodes: Array<{ key: string; id: string }> = []
+
+      editorState.read(() => {
+        const nodeMap = (editorState as any)._nodeMap as Map<string, any>
+        for (const [nodeKey, node] of nodeMap) {
+          const type = node.getType?.()
+          if (type === 'block' || type === 'inlineBlock') {
+            const fields = node.getFields?.()
+            if (fields?.id) {
+              blockNodes.push({ key: nodeKey, id: fields.id })
+            }
+          }
+        }
+      })
+
+      for (const { key, id } of blockNodes) {
+        const el = editor.getElementByKey(key)
+        if (el && el.getAttribute('data-block-id') !== id) {
+          el.setAttribute('data-block-id', id)
+        }
+      }
+    })
+  }, [editor])
+
+  return null
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -23,6 +23,7 @@ export type FocusBlockMessage = {
   type: `${typeof MESSAGE_PREFIX}focus-block`
   field: string
   index: number
+  richTextBlockId?: string
 }
 
 export function isFocusBlockMessage(data: unknown): data is FocusBlockMessage {
@@ -35,5 +36,59 @@ export function isFocusBlockMessage(data: unknown): data is FocusBlockMessage {
     typeof (data as FocusBlockMessage).field === 'string' &&
     'index' in data &&
     typeof (data as FocusBlockMessage).index === 'number'
+  )
+}
+
+export type ScrollToRichTextBlockMessage = {
+  type: `${typeof MESSAGE_PREFIX}scroll-to-richtext-block`
+  blockId: string
+}
+
+export function isScrollToRichTextBlockMessage(data: unknown): data is ScrollToRichTextBlockMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    (data as ScrollToRichTextBlockMessage).type === `${MESSAGE_PREFIX}scroll-to-richtext-block` &&
+    'blockId' in data &&
+    typeof (data as ScrollToRichTextBlockMessage).blockId === 'string'
+  )
+}
+
+export type ScrollToRichTextNestedBlockMessage = {
+  type: `${typeof MESSAGE_PREFIX}scroll-to-richtext-nested-block`
+  richTextBlockId: string
+  index: number
+}
+
+export function isScrollToRichTextNestedBlockMessage(
+  data: unknown,
+): data is ScrollToRichTextNestedBlockMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    (data as ScrollToRichTextNestedBlockMessage).type ===
+      `${MESSAGE_PREFIX}scroll-to-richtext-nested-block` &&
+    'richTextBlockId' in data &&
+    typeof (data as ScrollToRichTextNestedBlockMessage).richTextBlockId === 'string' &&
+    'index' in data &&
+    typeof (data as ScrollToRichTextNestedBlockMessage).index === 'number'
+  )
+}
+
+export type FocusRichTextBlockMessage = {
+  type: `${typeof MESSAGE_PREFIX}focus-richtext-block`
+  blockId: string
+}
+
+export function isFocusRichTextBlockMessage(data: unknown): data is FocusRichTextBlockMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    (data as FocusRichTextBlockMessage).type === `${MESSAGE_PREFIX}focus-richtext-block` &&
+    'blockId' in data &&
+    typeof (data as FocusRichTextBlockMessage).blockId === 'string'
   )
 }


### PR DESCRIPTION
# RichText (Lexical) block sync, Payload 3.81+ compatibility, and `data-preview-ignore`

## Summary

Fixes #2

This PR adds full bi-directional sync support for blocks embedded inside Lexical richText fields, fixes compatibility with Payload 3.81+ which changed the live preview iframe rendering, and introduces a `data-preview-ignore` escape hatch for custom components.

### Video showcase

https://github.com/user-attachments/assets/cb09201a-11b1-458d-88d7-ae587b4f3c45

---

## Payload 3.81+ compatibility fix

Payload 3.81 replaced the bare `<iframe>` in live preview with an `IframeLoader` wrapper component that overrides the element's `className`. The previous version of this plugin relied on `iframe.live-preview-iframe` (class selector) to locate the preview iframe — that class is no longer set on the element in 3.81+.

The `getPreviewIframe()` selector is now: `iframe#live-preview-iframe, iframe.live-preview-iframe, iframe[src*="/preview"], iframe[title*="preview"]` — ID first for 3.81+, class fallback for older versions. No breaking change.

---

## New features

### RichText (Lexical) block sync

Blocks embedded inside Lexical richText fields now participate in full bi-directional sync.

#### How it works

Lexical blocks do not have a field path or index that matches the Payload admin row structure. Instead, each block carries a unique BSON ID (`node.fields.id`). Sync is based on this ID rather than the field+index pair used by regular block fields.

- **Admin → Preview**: clicking a Lexical block row in the admin sends `scroll-to-richtext-block { blockId }` to the preview iframe. The preview finds `[data-block-id="${blockId}"]` and scrolls to it.
- **Preview → Admin**: clicking a block with `data-block-id` (but no `data-block-field`) sends `focus-richtext-block { blockId }`. The admin finds `[data-block-id="${blockId}"]`, expands the collapsible if needed, and scrolls to it.

#### `BetterPreviewLexicalFeature`

A new server feature stamps `data-block-id` onto every block decorator element in the Lexical editor DOM. Register it alongside `BlocksFeature` in your Payload config:

```ts
// payload.config.ts
import { betterPreview, BetterPreviewLexicalFeature } from 'payload-better-preview'
import { lexicalEditor, BlocksFeature } from '@payloadcms/richtext-lexical'

export default buildConfig({
  plugins: [betterPreview()],
  editor: lexicalEditor({
    features: ({ defaultFeatures }) => [
      ...defaultFeatures,
      BlocksFeature({ blocks: [...] }),
      BetterPreviewLexicalFeature(),
    ],
  }),
})
```

#### Frontend — add `data-block-id` in JSX converters

Add `data-block-id` to each block's wrapper element. The plugin uses this ID to match admin and preview:

```tsx
// jsxConverters.tsx
export const jsxConverters: JSXConvertersFunction = ({ defaultConverters }) => ({
  ...defaultConverters,
  blocks: {
    hero: ({ node }) => (
      <div
        data-block={node.fields.blockType}
        data-block-id={node.fields.id}
      >
        {/* block content */}
      </div>
    ),
  },
})
```

#### Nested blocks inside richText

For blocks that contain their own `blocks` field (e.g. a `nestedBlock`), sync is scoped to the parent richText block to avoid duplicate row ID collisions when multiple instances of the same block exist on the page.

- **Admin → Preview**: sends `scroll-to-richtext-nested-block { richTextBlockId, index }`. The preview finds the parent `[data-block-id]` first, then locates `[data-block-index="${index}"]` within it.
- **Preview → Admin**: sends `focus-block { field, index, richTextBlockId }`. The admin opens the parent Lexical block first, then scopes the row search to `parent.querySelector('[id="${localField}-row-${index}"]')`.

```tsx
// Outer richText block:
<div
  data-block={node.fields.blockType}
  data-block-id={node.fields.id}
>
  <RenderBlocks
    blocks={node.fields.content}
    field="content"             // local field name only
    richTextBlockId={node.fields.id}
  />
</div>

// Inner blocks:
<div
  data-block={block.blockType}
  data-block-id={block.id}
  data-block-index={index}
  data-block-field={field}     // e.g. "content"
>
```

#### New export path

The Lexical feature client component is exported under a separate entry point to keep Lexical imports server-only where needed:

```ts
import { BetterPreviewLexicalFeature } from 'payload-better-preview'          // server
import { BetterPreviewClientFeature } from 'payload-better-preview/lexical'   // client (internal)
```

---

### `data-preview-ignore`

Add `data-preview-ignore` to any element to prevent clicks on it from triggering scroll sync. Works in both directions:

- **Preview side** — blocks rendered in the frontend page (JSX converters). Prevents the preview from sending a `focus-block` / `focus-richtext-block` message to the admin.
- **Admin side** — custom block components inside the Lexical editor. Prevents the admin from sending a `scroll-to-`* message to the preview iframe.

```tsx
// Preview — JSX converter
blocks: {
  cta: ({ node }) => (
    <div data-block={node.fields.blockType} data-block-id={node.fields.id}>
      <button data-preview-ignore onClick={handleBuyNow}>Buy now</button>
    </div>
  ),
},

// Admin — custom Lexical block component
export function CtaBlockComponent({ formData }) {
  return (
    <div>
      <button data-preview-ignore onClick={openModal}>Edit link</button>
    </div>
  )
}
```

Any click originating inside a `[data-preview-ignore]` element is ignored entirely by the plugin.

---

## New message types

Four new `window.postMessage` message types were added to the internal protocol. All are prefixed with `better-preview:` and validated with type guards:


| Message type                      | Direction       | Payload                               |
| --------------------------------- | --------------- | ------------------------------------- |
| `scroll-to-richtext-block`        | Admin → Preview | `{ blockId }`                         |
| `focus-richtext-block`            | Preview → Admin | `{ blockId }`                         |
| `scroll-to-richtext-nested-block` | Admin → Preview | `{ richTextBlockId, index }`          |
| `focus-block` (extended)          | Preview → Admin | existing + optional `richTextBlockId` |


---

## Internal changes

- `getPreviewIframe()` in `AdminBlockSyncProvider` now selects by `iframe#live-preview-iframe` as primary selector, with fallbacks for other common patterns
- `AdminBlockSyncProvider` handles `focus-richtext-block` messages: expands collapsible if needed, waits 350ms for animation, then scrolls
- `ATTR_IGNORE = 'data-preview-ignore'` added to `constants.ts`

